### PR TITLE
Add proper OS abstraction to Director and Storagedaemon monit files

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,10 +61,22 @@ class bacula::params {
         }
     }
 
+    $bacula_director_pidfile = "${pid_directory}/bacula-dir.9101.pid"
+    $bacula_storagedaemon_pidfile = "${pid_directory}/bacula-sd.9103.pid"
+    $bacula_filedaemon_pidfile = "${pid_directory}/bacula-fd.9102.pid"
+
     if str2bool($::has_systemd) {
+        $bacula_director_service_start = "${::os::params::systemctl} start ${bacula_director_service}"
+        $bacula_director_service_stop = "${::os::params::systemctl} stop ${bacula_director_service}"
+        $bacula_storagedaemon_service_start = "${::os::params::systemctl} start ${bacula_storagedaemon_service}"
+        $bacula_storagedaemon_service_stop = "${::os::params::systemctl} stop ${bacula_storagedaemon_service}"
         $bacula_filedaemon_service_start = "${::os::params::systemctl} start ${bacula_filedaemon_service}"
         $bacula_filedaemon_service_stop = "${::os::params::systemctl} stop ${bacula_filedaemon_service}"
     } else {
+        $bacula_director_service_start = "${::os::params::service_cmd} ${bacula_director_service} start"
+        $bacula_director_service_stop = "${::os::params::service_cmd} ${bacula_director_service} stop"
+        $bacula_storagedaemon_service_start = "${::os::params::service_cmd} ${bacula_storagedaemon_service} start"
+        $bacula_storagedaemon_service_stop = "${::os::params::service_cmd} ${bacula_storagedaemon_service} stop"
         $bacula_filedaemon_service_start = "${::os::params::service_cmd} ${bacula_filedaemon_service} start"
         $bacula_filedaemon_service_stop = "${::os::params::service_cmd} ${bacula_filedaemon_service} stop"
     }

--- a/templates/bacula-dir.monit.erb
+++ b/templates/bacula-dir.monit.erb
@@ -1,6 +1,7 @@
-# FIXME: This is probably fairly Debian/Ubuntu specific
-check process bacula-dir with pidfile <%= scope.lookupvar('bacula::params::pid_directory') %>/bacula-dir.9101.pid
-        start "/etc/init.d/<%= scope.lookupvar('bacula::params::bacula_director_service') %> start"
-        stop  "/etc/init.d/<%= scope.lookupvar('bacula::params::bacula_director_service') %> stop"
-        alert <%= scope.lookupvar('bacula::director::monit::monitor_email') %> with reminder on 480 cycles
+### THIS FILE IS MANAGED BY PUPPET. ANY MANUAL CHANGES WILL GET OVERWRITTEN.
+
+check process bacula-dir with pidfile <%= scope['bacula::params::bacula_director_pidfile'] %>
+        start "<%= scope['::bacula::params::bacula_director_service_start'] %>"
+        stop "<%= scope['::bacula::params::bacula_director_service_stop'] %>"
+        alert <%= scope['::bacula::director::monit::monitor_email'] %> with reminder on 480 cycles
 

--- a/templates/bacula-fd.monit.erb
+++ b/templates/bacula-fd.monit.erb
@@ -1,6 +1,6 @@
 ### THIS FILE IS MANAGED BY PUPPET. ANY MANUAL CHANGES WILL GET OVERWRITTEN.
 
-check process bacula-fd with pidfile <%= scope['::bacula::params::pid_directory'] %>/bacula-fd.9102.pid
+check process bacula-fd with pidfile <%= scope['::bacula::params::bacula_filedaemon_pidfile'] %>
         start "<%= scope['::bacula::params::bacula_filedaemon_service_start'] %>"
         stop  "<%= scope['::bacula::params::bacula_filedaemon_service_stop'] %>"
         alert <%= scope['::bacula::filedaemon::monit::monitor_email'] %> with reminder on 480 cycles

--- a/templates/bacula-sd.monit.erb
+++ b/templates/bacula-sd.monit.erb
@@ -1,5 +1,7 @@
-# FIXME: This is probably fairly Debian/Ubuntu specific
-check process bacula-sd with pidfile <%= scope.lookupvar('bacula::params::pid_directory') %>/bacula-sd.9103.pid
-        start "/etc/init.d/<%= scope.lookupvar('bacula::params::bacula_storagedaemon_service') %> start"
-        stop  "/etc/init.d/<%= scope.lookupvar('bacula::params::bacula_storagedaemon_service') %> stop"
-        alert <%= scope.lookupvar('bacula::storagedaemon::monit::monitor_email') %> with reminder on 480 cycles 
+### THIS FILE IS MANAGED BY PUPPET. ANY MANUAL CHANGES WILL GET OVERWRITTEN.
+
+check process bacula-sd with pidfile <%= scope['bacula::params::bacula_storagedaemon_pidfile'] %>
+        start "<%= scope['::bacula::params::bacula_storagedaemon_service_start']%>"
+        stop "<%= scope['::bacula::params::bacula_storagedaemon_service_stop'] %>"
+        alert <%= scope['::bacula::storagedaemon::monit::monitor_email'] %> with reminder on 480 cycles
+


### PR DESCRIPTION
Previously the monit files were Ubuntu/Debian-specific, and did not take systemd
into account.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>